### PR TITLE
Add --cdp-url flag to connect to existing Chrome browser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ anyhow = "1"
 thiserror = "2"
 
 # CLI args
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 
 # Utility
 which = "7"

--- a/README.md
+++ b/README.md
@@ -102,6 +102,48 @@ That's it. Claude now has a browser.
 }
 ```
 
+### Connect to your existing browser
+
+Chrome 144+ has a built-in toggle that lets any agent connect to your running browser — no extensions needed.
+
+1. Open `chrome://inspect/#remote-debugging` in Chrome
+2. Enable the remote debugging toggle
+3. Connect remix-browser:
+
+```json
+{
+  "mcpServers": {
+    "remix-browser": {
+      "command": "/path/to/remix-browser",
+      "args": ["--cdp-url", "ws://127.0.0.1:9222"]
+    }
+  }
+}
+```
+
+Or use an environment variable:
+
+```json
+{
+  "mcpServers": {
+    "remix-browser": {
+      "command": "/path/to/remix-browser",
+      "env": {
+        "CDP_URL": "ws://127.0.0.1:9222"
+      }
+    }
+  }
+}
+```
+
+HTTP URLs also work — the WebSocket URL is auto-discovered from `/json/version`:
+
+```bash
+CDP_URL=http://127.0.0.1:9222 remix-browser
+```
+
+When connected to an external browser, remix-browser uses your existing tabs and gracefully disconnects on exit without closing Chrome.
+
 ### Best performance tip
 
 For the best experience, add this line to your project's `CLAUDE.md` (or `~/.claude/CLAUDE.md` for all projects):
@@ -231,6 +273,8 @@ This means clicks **just work** — even on sites with complex overlays, sticky 
 | Option | Default | Description |
 |---|---|---|
 | `--headed` | `false` | Show the browser window instead of running headless |
+| `--cdp-url` | — | Connect to an existing browser via CDP WebSocket or HTTP URL |
+| `CDP_URL` env var | — | Same as `--cdp-url` (env var alternative) |
 | `RUST_LOG` env var | `info` | Control log verbosity (`debug`, `trace`, etc.) |
 
 ### Chrome Detection

--- a/src/browser/session.rs
+++ b/src/browser/session.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use chromiumoxide::browser::{Browser, BrowserConfig};
+use chromiumoxide::handler::Handler;
 use chromiumoxide::page::Page;
 use futures::StreamExt;
 use std::sync::Arc;
@@ -13,11 +14,14 @@ pub struct BrowserSession {
     _handler_task: tokio::task::JoinHandle<()>,
     pub pool: Arc<Mutex<TabPool>>,
     headless: bool,
-    /// Whether this session is connected to an external browser (don't kill on close).
-    is_remote: bool,
     /// Unique temp dir for this Chrome instance — cleaned up on drop.
-    /// `None` for remote connections.
+    /// `None` for remote connections (connected via `--cdp-url`).
     _user_data_dir: Option<tempfile::TempDir>,
+}
+
+/// Spawn a task that drives the CDP event loop (must be polled to keep the connection alive).
+fn spawn_handler(mut handler: Handler) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move { while handler.next().await.is_some() {} })
 }
 
 impl BrowserSession {
@@ -49,17 +53,12 @@ impl BrowserSession {
 
         let config = builder.build().map_err(|e| anyhow::anyhow!("{}", e))?;
 
-        let (browser, mut handler) = Browser::launch(config)
+        let (browser, handler) = Browser::launch(config)
             .await
             .context("Failed to launch Chrome")?;
 
-        let handler_task = tokio::spawn(async move {
-            while let Some(_event) = handler.next().await {
-                // Process browser events
-            }
-        });
+        let handler_task = spawn_handler(handler);
 
-        // Create initial page
         let page = browser
             .new_page("about:blank")
             .await
@@ -67,14 +66,13 @@ impl BrowserSession {
 
         let pool = Arc::new(Mutex::new(TabPool::new(page)));
 
-        tracing::info!("Browser session started (headless: {})", headless);
+        tracing::info!("Browser launched (headless: {})", headless);
 
         Ok(Self {
             browser,
             _handler_task: handler_task,
             pool,
             headless,
-            is_remote: false,
             _user_data_dir: Some(user_data_dir),
         })
     }
@@ -84,20 +82,17 @@ impl BrowserSession {
     /// Accepts `ws://` WebSocket URLs or `http://` URLs (auto-discovers
     /// the WebSocket URL from the `/json/version` endpoint).
     pub async fn connect(cdp_url: &str) -> Result<Self> {
-        tracing::info!("Connecting to existing browser at {}", cdp_url);
-
-        let (browser, mut handler) = Browser::connect(cdp_url)
+        let (browser, handler) = Browser::connect(cdp_url)
             .await
-            .context(format!("Failed to connect to browser at {}", cdp_url))?;
+            .with_context(|| format!("Failed to connect to browser at {}", cdp_url))?;
 
-        let handler_task = tokio::spawn(async move {
-            while let Some(_event) = handler.next().await {
-                // Process browser events
-            }
-        });
+        let handler_task = spawn_handler(handler);
 
         // Use an existing page if available, otherwise create one
-        let pages = browser.pages().await.unwrap_or_default();
+        let pages = browser.pages().await.unwrap_or_else(|e| {
+            tracing::warn!("Failed to list existing pages: {}, creating new tab", e);
+            Vec::new()
+        });
         let page = if let Some(first_page) = pages.into_iter().next() {
             first_page
         } else {
@@ -116,9 +111,13 @@ impl BrowserSession {
             _handler_task: handler_task,
             pool,
             headless: false,
-            is_remote: true,
             _user_data_dir: None,
         })
+    }
+
+    /// Whether this session is connected to an external browser (vs locally launched).
+    pub fn is_remote(&self) -> bool {
+        self._user_data_dir.is_none()
     }
 
     /// Get the currently active page.
@@ -142,12 +141,8 @@ impl BrowserSession {
     /// Close the browser session.
     /// For remote connections, only disconnects without killing the browser.
     pub async fn close(self) -> Result<()> {
-        if self.is_remote {
-            tracing::info!("Disconnecting from remote browser (leaving it running)");
-            // Drop the browser handle without killing the process
-        } else {
-            tracing::info!("Closing local browser");
-        }
+        let mode = if self.is_remote() { "remote" } else { "local" };
+        tracing::info!("Closing {} browser session", mode);
         drop(self.browser);
         Ok(())
     }

--- a/src/browser/session.rs
+++ b/src/browser/session.rs
@@ -13,8 +13,11 @@ pub struct BrowserSession {
     _handler_task: tokio::task::JoinHandle<()>,
     pub pool: Arc<Mutex<TabPool>>,
     headless: bool,
+    /// Whether this session is connected to an external browser (don't kill on close).
+    is_remote: bool,
     /// Unique temp dir for this Chrome instance — cleaned up on drop.
-    _user_data_dir: tempfile::TempDir,
+    /// `None` for remote connections.
+    _user_data_dir: Option<tempfile::TempDir>,
 }
 
 impl BrowserSession {
@@ -71,7 +74,50 @@ impl BrowserSession {
             _handler_task: handler_task,
             pool,
             headless,
-            _user_data_dir: user_data_dir,
+            is_remote: false,
+            _user_data_dir: Some(user_data_dir),
+        })
+    }
+
+    /// Connect to an already-running browser via a CDP URL.
+    ///
+    /// Accepts `ws://` WebSocket URLs or `http://` URLs (auto-discovers
+    /// the WebSocket URL from the `/json/version` endpoint).
+    pub async fn connect(cdp_url: &str) -> Result<Self> {
+        tracing::info!("Connecting to existing browser at {}", cdp_url);
+
+        let (browser, mut handler) = Browser::connect(cdp_url)
+            .await
+            .context(format!("Failed to connect to browser at {}", cdp_url))?;
+
+        let handler_task = tokio::spawn(async move {
+            while let Some(_event) = handler.next().await {
+                // Process browser events
+            }
+        });
+
+        // Use an existing page if available, otherwise create one
+        let pages = browser.pages().await.unwrap_or_default();
+        let page = if let Some(first_page) = pages.into_iter().next() {
+            first_page
+        } else {
+            browser
+                .new_page("about:blank")
+                .await
+                .context("Failed to create initial page on remote browser")?
+        };
+
+        let pool = Arc::new(Mutex::new(TabPool::new(page)));
+
+        tracing::info!("Connected to remote browser at {}", cdp_url);
+
+        Ok(Self {
+            browser,
+            _handler_task: handler_task,
+            pool,
+            headless: false,
+            is_remote: true,
+            _user_data_dir: None,
         })
     }
 
@@ -93,9 +139,15 @@ impl BrowserSession {
         Ok(page)
     }
 
-    /// Close the browser.
+    /// Close the browser session.
+    /// For remote connections, only disconnects without killing the browser.
     pub async fn close(self) -> Result<()> {
-        // Browser drop will handle cleanup
+        if self.is_remote {
+            tracing::info!("Disconnecting from remote browser (leaving it running)");
+            // Drop the browser handle without killing the process
+        } else {
+            tracing::info!("Closing local browser");
+        }
         drop(self.browser);
         Ok(())
     }

--- a/src/interaction/wait.rs
+++ b/src/interaction/wait.rs
@@ -1,7 +1,7 @@
-use anyhow::Result;
-use chromiumoxide::page::Page;
 use crate::interaction::click::selector_to_js;
 use crate::selectors::SelectorType;
+use anyhow::Result;
+use chromiumoxide::page::Page;
 
 /// Wait up to `timeout_ms` for a selector to resolve to a non-null element.
 /// Returns Ok(()) when found, Err if timeout.
@@ -27,11 +27,14 @@ pub async fn wait_for_selector(
             .and_then(|r| r.into_value().ok())
             .unwrap_or(false);
 
-        if found { return Ok(()); }
+        if found {
+            return Ok(());
+        }
         if elapsed >= timeout_ms {
             anyhow::bail!(
                 "Timed out after {}ms waiting for element: {}",
-                timeout_ms, selector
+                timeout_ms,
+                selector
             );
         }
         tokio::time::sleep(std::time::Duration::from_millis(interval)).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,11 @@ struct Cli {
     /// Run Chrome with a visible window (default: headless)
     #[arg(long)]
     headed: bool,
+
+    /// Connect to an existing browser via CDP WebSocket URL (ws:// or http://).
+    /// When using http://, the WebSocket URL is auto-discovered from /json/version.
+    #[arg(long, env = "CDP_URL")]
+    cdp_url: Option<String>,
 }
 
 #[tokio::main]
@@ -28,9 +33,14 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     let headless = !cli.headed;
 
-    tracing::info!("Starting remix-browser MCP server (headless: {})", headless);
+    if let Some(ref url) = cli.cdp_url {
+        tracing::info!("Starting remix-browser MCP server (connecting to {})", url);
+    } else {
+        tracing::info!("Starting remix-browser MCP server (headless: {})", headless);
+    }
 
-    let server = remix_browser::server::RemixBrowserServer::new(headless);
+    let server =
+        remix_browser::server::RemixBrowserServer::new(headless).with_cdp_url(cli.cdp_url);
     let service = server.clone().serve(stdio()).await?;
 
     // Wait for MCP service to finish OR a termination signal — whichever comes first
@@ -41,7 +51,7 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    // Always kill Chrome before exiting
+    // Shut down browser session (disconnects from remote or kills local Chrome)
     server.shutdown().await;
 
     tracing::info!("remix-browser MCP server shut down");

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,14 +33,12 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     let headless = !cli.headed;
 
-    if let Some(ref url) = cli.cdp_url {
-        tracing::info!("Starting remix-browser MCP server (connecting to {})", url);
-    } else {
-        tracing::info!("Starting remix-browser MCP server (headless: {})", headless);
+    match &cli.cdp_url {
+        Some(url) => tracing::info!("Starting remix-browser MCP server (connecting to {})", url),
+        None => tracing::info!("Starting remix-browser MCP server (headless: {})", headless),
     }
 
-    let server =
-        remix_browser::server::RemixBrowserServer::new(headless).with_cdp_url(cli.cdp_url);
+    let server = remix_browser::server::RemixBrowserServer::new(headless, cli.cdp_url);
     let service = server.clone().serve(stdio()).await?;
 
     // Wait for MCP service to finish OR a termination signal — whichever comes first

--- a/src/selectors/mod.rs
+++ b/src/selectors/mod.rs
@@ -117,7 +117,10 @@ pub fn element_info_js() -> &'static str {
 }
 
 /// Detect Playwright-style :has-text("...") and convert to text selector.
-pub fn normalize_selector_type(selector: &str, selector_type: SelectorType) -> (String, SelectorType) {
+pub fn normalize_selector_type(
+    selector: &str,
+    selector_type: SelectorType,
+) -> (String, SelectorType) {
     if matches!(selector_type, SelectorType::Css) {
         if let Some(start) = selector.find(":has-text(") {
             let after = &selector[start + ":has-text(".len()..];
@@ -150,7 +153,8 @@ mod tests {
 
     #[test]
     fn test_normalize_has_text_single_quotes() {
-        let (sel, st) = normalize_selector_type("button:has-text('Create Account')", SelectorType::Css);
+        let (sel, st) =
+            normalize_selector_type("button:has-text('Create Account')", SelectorType::Css);
         assert_eq!(sel, "Create Account");
         assert!(matches!(st, SelectorType::Text));
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -49,6 +49,8 @@ pub struct RemixBrowserServer {
     network_log: network::NetworkLog,
     snapshot_refs: Arc<Mutex<HashMap<String, String>>>,
     headless: bool,
+    /// When set, connect to an existing browser at this CDP URL instead of launching.
+    cdp_url: Option<String>,
 }
 
 impl RemixBrowserServer {
@@ -59,7 +61,13 @@ impl RemixBrowserServer {
             network_log: network::NetworkLog::new(),
             snapshot_refs: Arc::new(Mutex::new(HashMap::new())),
             headless,
+            cdp_url: None,
         }
+    }
+
+    pub fn with_cdp_url(mut self, cdp_url: Option<String>) -> Self {
+        self.cdp_url = cdp_url;
+        self
     }
 
     /// Explicitly shut down the browser session, killing Chrome.
@@ -76,14 +84,24 @@ impl RemixBrowserServer {
         self.clear_snapshot_refs().await;
     }
 
-    /// Ensure the browser is launched, return a reference to the session.
+    /// Ensure the browser is launched or connected, return a reference to the session.
     async fn ensure_browser(&self) -> Result<(), McpError> {
         let mut session = self.session.lock().await;
         if session.is_none() {
-            tracing::info!("Launching browser (headless: {})", self.headless);
-            let s = BrowserSession::launch(self.headless).await.map_err(|e| {
-                McpError::internal_error(format!("Failed to launch browser: {}", e), None)
-            })?;
+            let s = if let Some(ref cdp_url) = self.cdp_url {
+                tracing::info!("Connecting to existing browser at {}", cdp_url);
+                BrowserSession::connect(cdp_url).await.map_err(|e| {
+                    McpError::internal_error(
+                        format!("Failed to connect to browser at {}: {}", cdp_url, e),
+                        None,
+                    )
+                })?
+            } else {
+                tracing::info!("Launching browser (headless: {})", self.headless);
+                BrowserSession::launch(self.headless).await.map_err(|e| {
+                    McpError::internal_error(format!("Failed to launch browser: {}", e), None)
+                })?
+            };
             *session = Some(s);
         }
         Ok(())
@@ -675,5 +693,18 @@ mod tests {
             .expect_err("missing ref should error");
 
         assert!(format!("{}", err).contains("Ref 'e99' not found, call snapshot again."));
+    }
+
+    #[test]
+    fn test_server_with_cdp_url() {
+        let server = RemixBrowserServer::new(true)
+            .with_cdp_url(Some("ws://127.0.0.1:9222".to_string()));
+        assert_eq!(server.cdp_url, Some("ws://127.0.0.1:9222".to_string()));
+    }
+
+    #[test]
+    fn test_server_without_cdp_url() {
+        let server = RemixBrowserServer::new(true).with_cdp_url(None);
+        assert_eq!(server.cdp_url, None);
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -54,23 +54,18 @@ pub struct RemixBrowserServer {
 }
 
 impl RemixBrowserServer {
-    pub fn new(headless: bool) -> Self {
+    pub fn new(headless: bool, cdp_url: Option<String>) -> Self {
         Self {
             session: Arc::new(Mutex::new(None)),
             console_log: javascript::ConsoleLog::new(),
             network_log: network::NetworkLog::new(),
             snapshot_refs: Arc::new(Mutex::new(HashMap::new())),
             headless,
-            cdp_url: None,
+            cdp_url,
         }
     }
 
-    pub fn with_cdp_url(mut self, cdp_url: Option<String>) -> Self {
-        self.cdp_url = cdp_url;
-        self
-    }
-
-    /// Explicitly shut down the browser session, killing Chrome.
+    /// Shut down the browser session.
     pub async fn shutdown(&self) {
         let session_to_close = {
             let mut session = self.session.lock().await;
@@ -84,24 +79,15 @@ impl RemixBrowserServer {
         self.clear_snapshot_refs().await;
     }
 
-    /// Ensure the browser is launched or connected, return a reference to the session.
+    /// Ensure the browser is launched or connected.
     async fn ensure_browser(&self) -> Result<(), McpError> {
         let mut session = self.session.lock().await;
         if session.is_none() {
-            let s = if let Some(ref cdp_url) = self.cdp_url {
-                tracing::info!("Connecting to existing browser at {}", cdp_url);
-                BrowserSession::connect(cdp_url).await.map_err(|e| {
-                    McpError::internal_error(
-                        format!("Failed to connect to browser at {}: {}", cdp_url, e),
-                        None,
-                    )
-                })?
-            } else {
-                tracing::info!("Launching browser (headless: {})", self.headless);
-                BrowserSession::launch(self.headless).await.map_err(|e| {
-                    McpError::internal_error(format!("Failed to launch browser: {}", e), None)
-                })?
-            };
+            let s = match &self.cdp_url {
+                Some(url) => BrowserSession::connect(url).await,
+                None => BrowserSession::launch(self.headless).await,
+            }
+            .map_err(|e| McpError::internal_error(format!("{:#}", e), None))?;
             *session = Some(s);
         }
         Ok(())
@@ -177,10 +163,13 @@ impl RemixBrowserServer {
     }
 
     async fn auto_snapshot(&self) -> String {
-        match self.with_page(|page| async move {
-            let params = snapshot::SnapshotParams { selector: None };
-            snapshot::snapshot_with_refs(&page, &params).await
-        }).await {
+        match self
+            .with_page(|page| async move {
+                let params = snapshot::SnapshotParams { selector: None };
+                snapshot::snapshot_with_refs(&page, &params).await
+            })
+            .await
+        {
             Ok(snap) => {
                 self.set_snapshot_refs(snap.refs).await;
                 snap.text
@@ -200,7 +189,10 @@ impl RemixBrowserServer {
                 // Auto-recovery: take fresh snapshot
                 let snap_text = self.auto_snapshot().await;
                 Err(McpError::internal_error(
-                    format!("Ref '{}' not found — page may have changed.\n\nCurrent page state:\n{}", ref_id, snap_text),
+                    format!(
+                        "Ref '{}' not found — page may have changed.\n\nCurrent page state:\n{}",
+                        ref_id, snap_text
+                    ),
                     None,
                 ))
             }
@@ -236,7 +228,10 @@ impl RemixBrowserServer {
             .with_page(|page| async move { navigation::navigate(&page, &params).await })
             .await?;
         let snap_text = self.auto_snapshot().await;
-        Self::text_result(format!("Navigated to {} — {}\n\nPage state:\n{}", result.title, result.url, snap_text))
+        Self::text_result(format!(
+            "Navigated to {} — {}\n\nPage state:\n{}",
+            result.title, result.url, snap_text
+        ))
     }
 
     #[tool(description = "Go back in browser history.")]
@@ -246,7 +241,10 @@ impl RemixBrowserServer {
             .with_page(|page| async move { navigation::go_back(&page).await })
             .await?;
         let snap_text = self.auto_snapshot().await;
-        Self::text_result(format!("Navigated back to {} — {}\n\nPage state:\n{}", result.title, result.url, snap_text))
+        Self::text_result(format!(
+            "Navigated back to {} — {}\n\nPage state:\n{}",
+            result.title, result.url, snap_text
+        ))
     }
 
     #[tool(description = "Go forward in browser history.")]
@@ -256,7 +254,10 @@ impl RemixBrowserServer {
             .with_page(|page| async move { navigation::go_forward(&page).await })
             .await?;
         let snap_text = self.auto_snapshot().await;
-        Self::text_result(format!("Navigated forward to {} — {}\n\nPage state:\n{}", result.title, result.url, snap_text))
+        Self::text_result(format!(
+            "Navigated forward to {} — {}\n\nPage state:\n{}",
+            result.title, result.url, snap_text
+        ))
     }
 
     #[tool(description = "Reload the current page.")]
@@ -266,7 +267,10 @@ impl RemixBrowserServer {
             .with_page(|page| async move { navigation::reload(&page).await })
             .await?;
         let snap_text = self.auto_snapshot().await;
-        Self::text_result(format!("Reloaded {} — {}\n\nPage state:\n{}", result.title, result.url, snap_text))
+        Self::text_result(format!(
+            "Reloaded {} — {}\n\nPage state:\n{}",
+            result.title, result.url, snap_text
+        ))
     }
 
     #[tool(description = "Get current page URL, title, and viewport size.")]
@@ -301,7 +305,9 @@ impl RemixBrowserServer {
         #[tool(aggr)] params: dom::GetTextParams,
     ) -> Result<CallToolResult, McpError> {
         let mut params = params;
-        params.selector = self.normalize_selector_with_recovery(&params.selector).await?;
+        params.selector = self
+            .normalize_selector_with_recovery(&params.selector)
+            .await?;
         let result = self
             .with_page(|page| async move { dom::get_text(&page, &params).await })
             .await?;
@@ -339,7 +345,9 @@ impl RemixBrowserServer {
         #[tool(aggr)] params: dom::WaitForParams,
     ) -> Result<CallToolResult, McpError> {
         let mut params = params;
-        params.selector = self.normalize_selector_with_recovery(&params.selector).await?;
+        params.selector = self
+            .normalize_selector_with_recovery(&params.selector)
+            .await?;
         let found = self
             .with_page(|page| async move { dom::wait_for(&page, &params).await })
             .await?;
@@ -347,7 +355,10 @@ impl RemixBrowserServer {
         if found {
             Self::text_result(format!("Element found\n\nPage state:\n{}", snap_text))
         } else {
-            Self::text_result(format!("Element not found (timeout)\n\nPage state:\n{}", snap_text))
+            Self::text_result(format!(
+                "Element not found (timeout)\n\nPage state:\n{}",
+                snap_text
+            ))
         }
     }
 
@@ -361,12 +372,17 @@ impl RemixBrowserServer {
         #[tool(aggr)] params: interaction::ClickParams,
     ) -> Result<CallToolResult, McpError> {
         let mut params = params;
-        params.selector = self.normalize_selector_with_recovery(&params.selector).await?;
+        params.selector = self
+            .normalize_selector_with_recovery(&params.selector)
+            .await?;
         let result = self
             .with_page(|page| async move { interaction::do_click(&page, &params).await })
             .await?;
         let snap_text = self.auto_snapshot().await;
-        Self::text_result(format!("Clicked element ({})\n\nPage state:\n{}", result.method_used, snap_text))
+        Self::text_result(format!(
+            "Clicked element ({})\n\nPage state:\n{}",
+            result.method_used, snap_text
+        ))
     }
 
     #[tool(description = "Type text into an element.")]
@@ -375,11 +391,16 @@ impl RemixBrowserServer {
         #[tool(aggr)] params: interaction::TypeTextParams,
     ) -> Result<CallToolResult, McpError> {
         let mut params = params;
-        params.selector = self.normalize_selector_with_recovery(&params.selector).await?;
+        params.selector = self
+            .normalize_selector_with_recovery(&params.selector)
+            .await?;
         self.with_page(|page| async move { interaction::type_text(&page, &params).await })
             .await?;
         let snap_text = self.auto_snapshot().await;
-        Self::text_result(format!("Typed text into element\n\nPage state:\n{}", snap_text))
+        Self::text_result(format!(
+            "Typed text into element\n\nPage state:\n{}",
+            snap_text
+        ))
     }
 
     #[tool(description = "Hover over an element.")]
@@ -388,11 +409,16 @@ impl RemixBrowserServer {
         #[tool(aggr)] params: interaction::HoverParams,
     ) -> Result<CallToolResult, McpError> {
         let mut params = params;
-        params.selector = self.normalize_selector_with_recovery(&params.selector).await?;
+        params.selector = self
+            .normalize_selector_with_recovery(&params.selector)
+            .await?;
         self.with_page(|page| async move { interaction::hover(&page, &params).await })
             .await?;
         let snap_text = self.auto_snapshot().await;
-        Self::text_result(format!("Hovered over element\n\nPage state:\n{}", snap_text))
+        Self::text_result(format!(
+            "Hovered over element\n\nPage state:\n{}",
+            snap_text
+        ))
     }
 
     #[tool(description = "Select an option from a <select> element.")]
@@ -401,20 +427,26 @@ impl RemixBrowserServer {
         #[tool(aggr)] params: interaction::SelectOptionParams,
     ) -> Result<CallToolResult, McpError> {
         let mut params = params;
-        params.selector = self.normalize_selector_with_recovery(&params.selector).await?;
+        params.selector = self
+            .normalize_selector_with_recovery(&params.selector)
+            .await?;
         self.with_page(|page| async move { interaction::select_option(&page, &params).await })
             .await?;
         let snap_text = self.auto_snapshot().await;
         Self::text_result(format!("Selected option\n\nPage state:\n{}", snap_text))
     }
 
-    #[tool(description = "Set the value of any form control (input, textarea, select, checkbox, slider). Smarter than type_text — auto-detects control type.")]
+    #[tool(
+        description = "Set the value of any form control (input, textarea, select, checkbox, slider). Smarter than type_text — auto-detects control type."
+    )]
     async fn fill(
         &self,
         #[tool(aggr)] params: interaction::FillParams,
     ) -> Result<CallToolResult, McpError> {
         let mut params = params;
-        params.selector = self.normalize_selector_with_recovery(&params.selector).await?;
+        params.selector = self
+            .normalize_selector_with_recovery(&params.selector)
+            .await?;
         let result = self
             .with_page(|page| async move { interaction::fill(&page, &params).await })
             .await?;
@@ -444,7 +476,10 @@ impl RemixBrowserServer {
         self.with_page(|page| async move { interaction::do_scroll(&page, &params).await })
             .await?;
         let snap_text = self.auto_snapshot().await;
-        Self::text_result(format!("Scrolled {} {}px\n\nPage state:\n{}", direction, amount, snap_text))
+        Self::text_result(format!(
+            "Scrolled {} {}px\n\nPage state:\n{}",
+            direction, amount, snap_text
+        ))
     }
 
     // ── Visual ──────────────────────────────────────────────────────────
@@ -611,7 +646,11 @@ impl RemixBrowserServer {
     ) -> Result<CallToolResult, McpError> {
         let current_refs = {
             let r = self.snapshot_refs.lock().await;
-            if r.is_empty() { None } else { Some(r.clone()) }
+            if r.is_empty() {
+                None
+            } else {
+                Some(r.clone())
+            }
         };
         let console_log = self.console_log.clone();
         let network_log = self.network_log.clone();
@@ -671,7 +710,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_normalize_selector_resolves_snapshot_ref() {
-        let server = RemixBrowserServer::new(true);
+        let server = RemixBrowserServer::new(true, None);
         let refs = HashMap::from([("e4".to_string(), "#submit-btn".to_string())]);
         server.set_snapshot_refs(refs).await;
 
@@ -685,7 +724,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_normalize_selector_stale_ref_has_guidance() {
-        let server = RemixBrowserServer::new(true);
+        let server = RemixBrowserServer::new(true, None);
 
         let err = server
             .normalize_selector("e99")
@@ -697,14 +736,13 @@ mod tests {
 
     #[test]
     fn test_server_with_cdp_url() {
-        let server = RemixBrowserServer::new(true)
-            .with_cdp_url(Some("ws://127.0.0.1:9222".to_string()));
+        let server = RemixBrowserServer::new(true, Some("ws://127.0.0.1:9222".to_string()));
         assert_eq!(server.cdp_url, Some("ws://127.0.0.1:9222".to_string()));
     }
 
     #[test]
-    fn test_server_without_cdp_url() {
-        let server = RemixBrowserServer::new(true).with_cdp_url(None);
+    fn test_server_without_cdp_url_defaults_to_none() {
+        let server = RemixBrowserServer::new(true, None);
         assert_eq!(server.cdp_url, None);
     }
 }

--- a/src/tools/interaction.rs
+++ b/src/tools/interaction.rs
@@ -23,7 +23,8 @@ pub struct ClickResult {
 
 pub async fn do_click(page: &Page, params: &ClickParams) -> Result<ClickResult> {
     let selector_type = params.selector_type.clone().unwrap_or_default();
-    let (selector, selector_type) = crate::selectors::normalize_selector_type(&params.selector, selector_type);
+    let (selector, selector_type) =
+        crate::selectors::normalize_selector_type(&params.selector, selector_type);
     let button = params.button.as_deref().unwrap_or("left");
 
     let result = click::hybrid_click(page, &selector, &selector_type, button).await?;
@@ -48,17 +49,11 @@ pub struct TypeTextParams {
 
 pub async fn type_text(page: &Page, params: &TypeTextParams) -> Result<bool> {
     let selector_type = params.selector_type.clone().unwrap_or_default();
-    let (selector, selector_type) = crate::selectors::normalize_selector_type(&params.selector, selector_type);
+    let (selector, selector_type) =
+        crate::selectors::normalize_selector_type(&params.selector, selector_type);
     let clear_first = params.clear_first.unwrap_or(false);
 
-    keyboard::type_text(
-        page,
-        &selector,
-        &selector_type,
-        &params.text,
-        clear_first,
-    )
-    .await?;
+    keyboard::type_text(page, &selector, &selector_type, &params.text, clear_first).await?;
 
     Ok(true)
 }
@@ -73,7 +68,8 @@ pub struct HoverParams {
 
 pub async fn hover(page: &Page, params: &HoverParams) -> Result<bool> {
     let selector_type = params.selector_type.clone().unwrap_or_default();
-    let (selector, selector_type) = crate::selectors::normalize_selector_type(&params.selector, selector_type);
+    let (selector, selector_type) =
+        crate::selectors::normalize_selector_type(&params.selector, selector_type);
     let selector_js = click::selector_to_js(&selector, &selector_type)?;
 
     let js = format!(
@@ -109,7 +105,8 @@ pub struct SelectOptionParams {
 
 pub async fn select_option(page: &Page, params: &SelectOptionParams) -> Result<bool> {
     let selector_type = params.selector_type.clone().unwrap_or_default();
-    let (selector, selector_type) = crate::selectors::normalize_selector_type(&params.selector, selector_type);
+    let (selector, selector_type) =
+        crate::selectors::normalize_selector_type(&params.selector, selector_type);
     let selector_js = click::selector_to_js(&selector, &selector_type)?;
 
     let js = format!(
@@ -175,7 +172,9 @@ pub async fn do_scroll(page: &Page, params: &ScrollParams) -> Result<bool> {
 pub struct FillParams {
     #[schemars(description = "Selector for the form element")]
     pub selector: String,
-    #[schemars(description = "Value to set (text for inputs, 'true'/'false' for checkboxes, numeric string for sliders)")]
+    #[schemars(
+        description = "Value to set (text for inputs, 'true'/'false' for checkboxes, numeric string for sliders)"
+    )]
     pub value: String,
     #[schemars(description = "Type of selector: css, text, or xpath")]
     pub selector_type: Option<SelectorType>,
@@ -183,7 +182,8 @@ pub struct FillParams {
 
 pub async fn fill(page: &Page, params: &FillParams) -> Result<String> {
     let selector_type = params.selector_type.clone().unwrap_or_default();
-    let (selector, selector_type) = crate::selectors::normalize_selector_type(&params.selector, selector_type);
+    let (selector, selector_type) =
+        crate::selectors::normalize_selector_type(&params.selector, selector_type);
 
     // Auto-wait for element
     crate::interaction::wait::wait_for_selector(page, &selector, &selector_type, 5000).await?;

--- a/src/tools/javascript.rs
+++ b/src/tools/javascript.rs
@@ -23,9 +23,7 @@ pub async fn execute_js(page: &Page, params: &ExecuteJsParams) -> Result<serde_j
             format!("Failed to evaluate JavaScript: {}", preview)
         })?;
 
-    let val: serde_json::Value = eval_result
-        .into_value()
-        .unwrap_or(serde_json::Value::Null);
+    let val: serde_json::Value = eval_result.into_value().unwrap_or(serde_json::Value::Null);
 
     // Detect DOM element results: CDP serializes DOM nodes as empty objects `{}`
     // When a DOM query pattern is present and the result is an empty object,
@@ -33,8 +31,10 @@ pub async fn execute_js(page: &Page, params: &ExecuteJsParams) -> Result<serde_j
     if let serde_json::Value::Object(ref map) = val {
         if map.is_empty() {
             let expr = &params.expression;
-            if expr.contains("querySelector") || expr.contains("getElementById")
-                || expr.contains("getElementsBy") || expr.contains("elementFromPoint")
+            if expr.contains("querySelector")
+                || expr.contains("getElementById")
+                || expr.contains("getElementsBy")
+                || expr.contains("elementFromPoint")
             {
                 anyhow::bail!(
                     "Expression returned a DOM element which cannot be serialized to JSON. \

--- a/src/tools/script.rs
+++ b/src/tools/script.rs
@@ -217,11 +217,7 @@ fn build_page_object(ctx: &Arc<ScriptContext>, js_ctx: &mut Context) -> JsValue 
         0,
     );
     builder.function(make_url(ctx.clone()), boa_engine::js_string!("url"), 0);
-    builder.function(
-        make_title(ctx.clone()),
-        boa_engine::js_string!("title"),
-        0,
-    );
+    builder.function(make_title(ctx.clone()), boa_engine::js_string!("title"), 0);
 
     // Interaction
     builder.function(make_click(ctx.clone()), boa_engine::js_string!("click"), 2);
@@ -550,7 +546,10 @@ fn make_click(ctx: Arc<ScriptContext>) -> NativeFunction {
             let options = args.get_or_undefined(1).clone();
 
             let selector_type = parse_selector_type(&options, js_ctx);
-            let (selector_str, selector_type) = crate::selectors::normalize_selector_type(&selector_str, selector_type.unwrap_or_default());
+            let (selector_str, selector_type) = crate::selectors::normalize_selector_type(
+                &selector_str,
+                selector_type.unwrap_or_default(),
+            );
 
             let params = interaction::ClickParams {
                 selector: selector_str,
@@ -582,7 +581,10 @@ fn make_type(ctx: Arc<ScriptContext>) -> NativeFunction {
             let options = args.get_or_undefined(2).clone();
 
             let selector_type = parse_selector_type(&options, js_ctx);
-            let (selector_str, selector_type) = crate::selectors::normalize_selector_type(&selector_str, selector_type.unwrap_or_default());
+            let (selector_str, selector_type) = crate::selectors::normalize_selector_type(
+                &selector_str,
+                selector_type.unwrap_or_default(),
+            );
 
             let params = interaction::TypeTextParams {
                 selector: selector_str,
@@ -610,7 +612,10 @@ fn make_hover(ctx: Arc<ScriptContext>) -> NativeFunction {
             let options = args.get_or_undefined(1).clone();
 
             let selector_type = parse_selector_type(&options, js_ctx);
-            let (selector_str, selector_type) = crate::selectors::normalize_selector_type(&selector_str, selector_type.unwrap_or_default());
+            let (selector_str, selector_type) = crate::selectors::normalize_selector_type(
+                &selector_str,
+                selector_type.unwrap_or_default(),
+            );
 
             let params = interaction::HoverParams {
                 selector: selector_str,
@@ -637,7 +642,10 @@ fn make_select(ctx: Arc<ScriptContext>) -> NativeFunction {
             let options = args.get_or_undefined(2).clone();
 
             let selector_type = parse_selector_type(&options, js_ctx);
-            let (selector_str, selector_type) = crate::selectors::normalize_selector_type(&selector_str, selector_type.unwrap_or_default());
+            let (selector_str, selector_type) = crate::selectors::normalize_selector_type(
+                &selector_str,
+                selector_type.unwrap_or_default(),
+            );
 
             let params = interaction::SelectOptionParams {
                 selector: selector_str,
@@ -666,7 +674,8 @@ fn make_fill(ctx: Arc<ScriptContext>) -> NativeFunction {
 
             let selector_type = parse_selector_type(&options, js_ctx);
             let (selector_str, selector_type) = crate::selectors::normalize_selector_type(
-                &selector_str, selector_type.unwrap_or_default()
+                &selector_str,
+                selector_type.unwrap_or_default(),
             );
 
             let params = interaction::FillParams {
@@ -676,7 +685,8 @@ fn make_fill(ctx: Arc<ScriptContext>) -> NativeFunction {
             };
 
             let page = ctx.page.clone();
-            let result = ctx.handle
+            let result = ctx
+                .handle
                 .block_on(async { interaction::fill(&page, &params).await })
                 .map_err(js_err)?;
 
@@ -920,14 +930,16 @@ fn make_js(ctx: Arc<ScriptContext>) -> NativeFunction {
             let refs_guard = ctx.snapshot_refs.lock().unwrap();
             if let Some(ref refs) = *refs_guard {
                 let re = regex::Regex::new(r"\[ref=e(\d+)\]").unwrap();
-                expr_str = re.replace_all(&expr_str, |caps: &regex::Captures| {
-                    let ref_id = format!("e{}", &caps[1]);
-                    if let Some(css_sel) = refs.get(&ref_id) {
-                        css_sel.clone()
-                    } else {
-                        caps[0].to_string()
-                    }
-                }).to_string();
+                expr_str = re
+                    .replace_all(&expr_str, |caps: &regex::Captures| {
+                        let ref_id = format!("e{}", &caps[1]);
+                        if let Some(css_sel) = refs.get(&ref_id) {
+                            css_sel.clone()
+                        } else {
+                            caps[0].to_string()
+                        }
+                    })
+                    .to_string();
             }
             drop(refs_guard);
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1540,10 +1540,15 @@ async fn test_run_script_preloaded_refs() {
     );
 
     let params = remix_browser::tools::script::RunScriptParams { script };
-    let (result, _screenshots, _refs) =
-        remix_browser::tools::script::run_script(&page, &params, &console_log, &network_log, Some(snap.refs))
-            .await
-            .unwrap();
+    let (result, _screenshots, _refs) = remix_browser::tools::script::run_script(
+        &page,
+        &params,
+        &console_log,
+        &network_log,
+        Some(snap.refs),
+    )
+    .await
+    .unwrap();
 
     assert!(
         result.success,
@@ -1616,7 +1621,10 @@ async fn test_execute_js_dom_element_returns_helpful_error() {
     };
 
     let result = remix_browser::tools::javascript::execute_js(&page, &params).await;
-    assert!(result.is_err(), "querySelector returning DOM element should error");
+    assert!(
+        result.is_err(),
+        "querySelector returning DOM element should error"
+    );
     let err_msg = result.unwrap_err().to_string();
     assert!(
         err_msg.contains("DOM element"),
@@ -1676,7 +1684,10 @@ async fn test_auto_wait_click() {
 
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     let title = page.get_title().await.unwrap().unwrap_or_default();
-    assert_eq!(title, "Clicked!", "Click should have fired on delayed element");
+    assert_eq!(
+        title, "Clicked!",
+        "Click should have fired on delayed element"
+    );
 }
 
 #[tokio::test]
@@ -1751,7 +1762,11 @@ async fn test_fill_text_input() {
     )
     .await;
 
-    assert!(result.is_ok(), "fill() text input should succeed, error: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "fill() text input should succeed, error: {:?}",
+        result.err()
+    );
 
     let value: String = page
         .evaluate("document.getElementById('name').value")
@@ -1797,7 +1812,11 @@ async fn test_fill_checkbox() {
     )
     .await;
 
-    assert!(result.is_ok(), "fill() checkbox should succeed, error: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "fill() checkbox should succeed, error: {:?}",
+        result.err()
+    );
 
     let checked: bool = page
         .evaluate("document.getElementById('test-checkbox').checked")
@@ -1847,7 +1866,11 @@ async fn test_fill_range_slider() {
     )
     .await;
 
-    assert!(result.is_ok(), "fill() range should succeed, error: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "fill() range should succeed, error: {:?}",
+        result.err()
+    );
 
     let value: String = page
         .evaluate("document.getElementById('volume').value")
@@ -1877,7 +1900,11 @@ async fn test_fill_select() {
     )
     .await;
 
-    assert!(result.is_ok(), "fill() select should succeed, error: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "fill() select should succeed, error: {:?}",
+        result.err()
+    );
 
     let value: String = page
         .evaluate("document.getElementById('color').value")


### PR DESCRIPTION
Chrome 144+ exposes a built-in CDP toggle at chrome://inspect/#remote-debugging,
allowing agents to connect to an existing browser without extensions. This adds
support for connecting to those browsers via --cdp-url (or CDP_URL env var).

When connected remotely, remix-browser gracefully disconnects on shutdown
without killing the external browser process.

https://claude.ai/code/session_01W7baHkUqG7WrJs6KvstfkB